### PR TITLE
pass task timeout test

### DIFF
--- a/src/main/java/com/ftc11392/sequoia/task/Scheduler.java
+++ b/src/main/java/com/ftc11392/sequoia/task/Scheduler.java
@@ -91,6 +91,7 @@ public final class Scheduler {
 	private void initTask(Task task) {
 		task.setTelemetry(telemetry);
 		scheduledTasks.add(task);
+		task.running = true;
 		task.init();
 		Subsystem[] taskSubsystems = task.getSubsystems().toArray(new Subsystem[0]);
 		for (int i = 0; i < taskSubsystems.length; i++) {

--- a/src/main/java/com/ftc11392/sequoia/task/Task.java
+++ b/src/main/java/com/ftc11392/sequoia/task/Task.java
@@ -12,7 +12,7 @@ public abstract class Task {
 	protected Telemetry telemetry;
 
 	protected boolean interruptible = true;
-	protected boolean running = true;
+	protected boolean running = false;
 
 	/**
 	 * Adds {@link Subsystem} to the Task as dependencies for it to be scheduled.


### PR DESCRIPTION
resolves issues with bundles, which require tasks to be stopped before being able to add them.